### PR TITLE
Add support for Buffer and Stream in `send`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 import { Server } from 'http'
 import getRawBody from 'raw-body'
 import typer from 'media-typer'
+import isStream from 'isstream';
 
 const DEV = 'development' === process.env.NODE_ENV
 
@@ -48,28 +49,37 @@ export function send (res, code, obj = null) {
   res.statusCode = code
 
   if (null != obj) {
-    let str
-
-    if ('object' === typeof obj) {
-      // we stringify before setting the header
-      // in case `JSON.stringify` throws and a
-      // 500 has to be sent instead
-
-      // the `JSON.stringify` call is split into
-      // two cases as `JSON.stringify` is optimized
-      // in V8 if called with only one argument
-      if (DEV) {
-        str = JSON.stringify(obj, null, 2)
-      } else {
-        str = JSON.stringify(obj)
-      }
-      res.setHeader('Content-Type', 'application/json')
+    if (Buffer.isBuffer(obj)) {
+      res.setHeader('Content-Type', 'application/octet-stream')
+      res.setHeader('Content-Length', obj.length)
+      res.end(obj)
+    } else if (isStream(obj)) {
+      res.setHeader('Content-Type', 'application/octet-stream')
+      obj.pipe(res)
     } else {
-      str = obj
-    }
+      let str
 
-    res.setHeader('Content-Length', Buffer.byteLength(str))
-    res.end(str)
+      if ('object' === typeof obj) {
+        // we stringify before setting the header
+        // in case `JSON.stringify` throws and a
+        // 500 has to be sent instead
+
+        // the `JSON.stringify` call is split into
+        // two cases as `JSON.stringify` is optimized
+        // in V8 if called with only one argument
+        if (DEV) {
+          str = JSON.stringify(obj, null, 2)
+        } else {
+          str = JSON.stringify(obj)
+        }
+        res.setHeader('Content-Type', 'application/json')
+      } else {
+        str = obj
+      }
+
+      res.setHeader('Content-Length', Buffer.byteLength(str))
+      res.end(str)
+    }
   } else {
     res.end()
   }

--- a/package.json
+++ b/package.json
@@ -48,8 +48,9 @@
   },
   "dependencies": {
     "babel-regenerator-runtime": "6.5.0",
+    "isstream": "0.1.2",
     "media-typer": "0.3.0",
-    "raw-body": "2.1.6",
-    "minimist": "1.2.0"
+    "minimist": "1.2.0",
+    "raw-body": "2.1.6"
   }
 }


### PR DESCRIPTION
If the obj passed to `send` is either a Buffer or Stream, `send`
now writes an octet-stream to the response.

Should handily resolve https://github.com/zeit/micro/issues/40.

Tests to come in [micro](https://github.com/zeit/micro)!