### PR TITLE
micro-serve: add 'use strict' directive

### DIFF
--- a/bin/micro-serve
+++ b/bin/micro-serve
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+'use strict';
+
 const argv = require('minimist')(process.argv.slice(2));
 const path = require('path');
 const serve = require('../dist').default;


### PR DESCRIPTION
Otherwise with Node.js v4.x, you get an error:

```
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```