### PR TITLE
Export `createError`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,7 +95,7 @@ export function sendError (req, res, { statusCode, message, stack }) {
   console.error(stack)
 }
 
-function createError (code, msg, orig) {
+export function createError (code, msg, orig) {
   const err = new Error(msg)
   err.statusCode = code
   err.originalError = orig


### PR DESCRIPTION
It's pretty useful to be able to just do

```js
throw createError(401, 'Not authenticated')
```

Instead of having to re-create ``createError`` in your own projects.